### PR TITLE
Test async functions using asyncio

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,3 @@
 pytest
 pytest-cov
-trio; python_version >= '3.5'
-pytest-trio; python_version >= '3.5'
+pytest-asyncio; python_version >= '3.5'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-cov
 pytest-asyncio; python_version >= '3.5'
+async-generator; python_version >= '3.5'

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,25 +1,25 @@
+import asyncio
 import sys
 
 import pytest
-import trio
 from async_generator import async_generator, yield_
 
 import outcome
 from outcome import Error, Value, AlreadyUsedError
 
-pytestmark = pytest.mark.trio
+pytestmark = pytest.mark.asyncio
 
 
 async def test_acapture():
     async def add(x, y):
-        await trio.hazmat.checkpoint()
+        await asyncio.sleep(0)
         return x + y
 
     v = await outcome.acapture(add, 3, y=4)
     assert v == Value(7)
 
     async def raise_ValueError(x):
-        await trio.hazmat.checkpoint()
+        await asyncio.sleep(0)
         raise ValueError(x)
 
     e = await outcome.acapture(raise_ValueError, 9)


### PR DESCRIPTION
Our tests use trio and trio uses outcome. Let’s avoid having a test dependency use the code under test.

Fixes #12