### PR TITLE
Update Travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,27 @@
 language: python
-python:
-  - 2.7
-  - 3.4
-  - 3.5.0
-  - 3.5.2
-  - 3.5-dev
-  - 3.6
-  - 3.6-dev
-  - 3.7-dev
 sudo: false
 dist: trusty
 
 matrix:
   include:
-    - os: linux
-      language: generic
-      env: USE_PYPY_RELEASE_VERSION=5.9-beta
-    - os: linux
-      language: python
-      python: 3.6
+    - python: 3.6
       env: CHECK_DOCS=1
-    - os: linux
-      language: python
-      python: 3.6
+    - python: 3.6
       env: CHECK_FORMATTING=1
+    - python: pypy
+    - python: pypy3.5
+    - python: 2.7
+    - python: 3.4
+    - python: 3.5.0
+    - python: 3.5.2
+    - python: 3.6
+    - python: 3.7
+      dist: xenial
+      sudo: required
+    - python: 3.8-dev
+      dist: xenial
+      sudo: required
+
 
 script:
   - ci/travis.sh

--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -39,18 +39,6 @@ if [ "$USE_PYPY_NIGHTLY" = "1" ]; then
     source testenv/bin/activate
 fi
 
-if [ "$USE_PYPY_RELEASE_VERSION" != "" ]; then
-    curl -fLo pypy.tar.bz2 https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.5-${USE_PYPY_RELEASE_VERSION}-linux_x86_64-portable.tar.bz2
-    tar xaf pypy.tar.bz2
-    # something like "pypy3.5-5.7.1-beta-linux_x86_64-portable"
-    PYPY_DIR=$(echo pypy3.5-*)
-    PYTHON_EXE=$PYPY_DIR/bin/pypy3
-    $PYTHON_EXE -m ensurepip
-    $PYTHON_EXE -m pip install virtualenv
-    $PYTHON_EXE -m virtualenv testenv
-    source testenv/bin/activate
-fi
-
 pip install -U pip setuptools wheel
 
 if [ "$CHECK_FORMATTING" = "1" ]; then


### PR DESCRIPTION
- removed 3.5-dev and 3.6-dev
- Add 3.7 and 3.8-dev, requiring xenial with sudo
- Use Travis’s PyPy builds
