### PR TITLE
Cleaner tracebacks for captured exceptions

### DIFF
--- a/newsfragments/21.feature.rst
+++ b/newsfragments/21.feature.rst
@@ -1,0 +1,2 @@
+On Python 3, the exception frame generated within :func:`capture` and
+:func:`acapture` has been removed from the traceback.

--- a/src/outcome/_async.py
+++ b/src/outcome/_async.py
@@ -3,6 +3,7 @@ import abc
 from ._sync import Error as ErrorBase
 from ._sync import Outcome as OutcomeBase
 from ._sync import Value as ValueBase
+from ._util import remove_tb_frames
 
 __all__ = ['Error', 'Outcome', 'Value', 'acapture', 'capture']
 
@@ -18,6 +19,7 @@ def capture(sync_fn, *args, **kwargs):
     try:
         return Value(sync_fn(*args, **kwargs))
     except BaseException as exc:
+        exc = remove_tb_frames(exc, 1)
         return Error(exc)
 
 
@@ -31,6 +33,7 @@ async def acapture(async_fn, *args, **kwargs):
     try:
         return Value(await async_fn(*args, **kwargs))
     except BaseException as exc:
+        exc = remove_tb_frames(exc, 1)
         return Error(exc)
 
 

--- a/src/outcome/_sync.py
+++ b/src/outcome/_sync.py
@@ -5,7 +5,7 @@ import abc
 
 import attr
 
-from ._util import ABC, AlreadyUsedError
+from ._util import ABC, AlreadyUsedError, remove_tb_frames
 
 __all__ = ['Error', 'Outcome', 'Value', 'capture']
 
@@ -20,6 +20,7 @@ def capture(sync_fn, *args, **kwargs):
     try:
         return Value(sync_fn(*args, **kwargs))
     except BaseException as exc:
+        exc = remove_tb_frames(exc, 1)
         return Error(exc)
 
 
@@ -104,7 +105,10 @@ class Error(Outcome):
 
     def unwrap(self):
         self._set_unwrapped()
-        raise self.error
+        # Tracebacks show the 'raise' line below out of context, so let's give
+        # this variable a name that makes sense out of context.
+        captured_error = self.error
+        raise captured_error
 
     def send(self, it):
         self._set_unwrapped()

--- a/src/outcome/_util.py
+++ b/src/outcome/_util.py
@@ -24,6 +24,15 @@ def fixup_module_metadata(module_name, namespace):
         fix_one(obj)
 
 
+def remove_tb_frames(exc, n):
+    if sys.version_info < (3,):
+        return exc
+    tb = exc.__traceback__
+    for _ in range(n):
+        tb = tb.tb_next
+    return exc.with_traceback(tb)
+
+
 if sys.version_info < (3,):
 
     class ABC(object):

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -58,11 +58,8 @@ async def test_traceback_frame_removal():
         raise ValueError(x)
 
     e = await outcome.acapture(raise_ValueError, 'abc')
-    try:
+    with pytest.raises(ValueError) as exc_info:
         e.unwrap()
-    except Exception as exc:
-        frames = traceback.extract_tb(exc.__traceback__)
-        functions = [function for _, _, function, _ in frames]
-        assert functions[-2:] == ['unwrap', 'raise_ValueError']
-    else:
-        pytest.fail('Did not raise')
+    frames = traceback.extract_tb(exc_info.value.__traceback__)
+    functions = [function for _, _, function, _ in frames]
+    assert functions[-2:] == ['unwrap', 'raise_ValueError']

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,4 +1,5 @@
 import sys
+import traceback
 
 import pytest
 import trio
@@ -50,3 +51,18 @@ async def test_asend():
         await e.asend(my_agen)
     with pytest.raises(StopAsyncIteration):
         await my_agen.asend(None)
+
+
+async def test_traceback_frame_removal():
+    async def raise_ValueError(x):
+        raise ValueError(x)
+
+    e = await outcome.acapture(raise_ValueError, 'abc')
+    try:
+        e.unwrap()
+    except Exception as exc:
+        frames = traceback.extract_tb(exc.__traceback__)
+        functions = [function for _, _, function, _ in frames]
+        assert functions[-2:] == ['unwrap', 'raise_ValueError']
+    else:
+        pytest.fail('Did not raise')

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function
 
 import sys
+import traceback
 
 import pytest
 
@@ -109,3 +110,19 @@ def test_capture():
 def test_inheritance():
     assert issubclass(Value, outcome.Outcome)
     assert issubclass(Error, outcome.Outcome)
+
+
+@pytest.mark.skipif(sys.version_info < (3,), reason="requires python 3")
+def test_traceback_frame_removal():
+    def raise_ValueError(x):
+        raise ValueError(x)
+
+    e = outcome.capture(raise_ValueError, 'abc')
+    try:
+        e.unwrap()
+    except Exception as exc:
+        frames = traceback.extract_tb(exc.__traceback__)
+        functions = [function for _, _, function, _ in frames]
+        assert functions[-2:] == ['unwrap', 'raise_ValueError']
+    else:
+        pytest.fail('Did not raise')

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -118,11 +118,8 @@ def test_traceback_frame_removal():
         raise ValueError(x)
 
     e = outcome.capture(raise_ValueError, 'abc')
-    try:
+    with pytest.raises(ValueError) as exc_info:
         e.unwrap()
-    except Exception as exc:
-        frames = traceback.extract_tb(exc.__traceback__)
-        functions = [function for _, _, function, _ in frames]
-        assert functions[-2:] == ['unwrap', 'raise_ValueError']
-    else:
-        pytest.fail('Did not raise')
+    frames = traceback.extract_tb(exc_info.value.__traceback__)
+    functions = [function for _, _, function, _ in frames]
+    assert functions[-2:] == ['unwrap', 'raise_ValueError']


### PR DESCRIPTION
Inspired by python-trio/trio#643

The tracebacks were not quite as bad as trio's, but I'm glad to get rid of the `return Value(...)` line:

**Before**
```
Traceback (most recent call last):
  File "/.../outcome/wip.py", line 13, in <module>
    result = outcome.capture(fn1).unwrap()
  File "/.../outcome/src/outcome/_sync.py", line 110, in unwrap
    raise self.error
  File "/.../outcome/src/outcome/_async.py", line 20, in capture
    return Value(sync_fn(*args, **kwargs))
  File "/.../outcome/wip.py", line 6, in fn1
    raise ValueError
ValueError
```

**After**
```
Traceback (most recent call last):
  File "/.../outcome/wip.py", line 13, in <module>
    result = outcome.capture(fn1).unwrap()
  File "/.../outcome/src/outcome/_sync.py", line 111, in unwrap
    raise captured_error
  File "/.../outcome/wip.py", line 6, in fn1
    raise ValueError
ValueError
```