### PR TITLE
Make setuptools license field SPDX-compliant

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     long_description_content_type='text/x-rst',
     author='Frazer McLean',
     author_email='frazer@frazermclean.co.uk',
-    license='MIT -or- Apache License 2.0',
+    license='MIT OR Apache-2.0',
     packages=find_packages('src'),
     package_dir={'': 'src'},
     install_requires=['attrs>=19.2.0'],


### PR DESCRIPTION
https://spdx.org/licenses/
https://spdx.github.io/spdx-spec/SPDX-license-expressions/#d42-disjunctive-or-operator

As approved by @njsmith here: [gitter.im/python-trio/general?at=6299a6fb4e38f759e29ffb3c](https://gitter.im/python-trio/general?at=6299a6fb4e38f759e29ffb3c)