### PR TITLE
remove reference to value/error when unwrapping outcome, and add `.peek()` method

### DIFF
--- a/newsfragments/47.feature.rst
+++ b/newsfragments/47.feature.rst
@@ -1,3 +1,4 @@
 Remove reference to value/error when unwrapping outcome.
 Provide a ``.peek()`` method to recieve wrapped
-value/error without invalidating the outcome.
+value or a copy of the wrapped error
+without invalidating the outcome.

--- a/newsfragments/47.feature.rst
+++ b/newsfragments/47.feature.rst
@@ -1,0 +1,3 @@
+Remove reference to value/error when unwrapping outcome.
+Provide a ``.peek()`` method to recieve wrapped
+value/error without invalidating the outcome.

--- a/src/outcome/_impl.py
+++ b/src/outcome/_impl.py
@@ -180,10 +180,7 @@ class Value(Outcome[ValueT], Generic[ValueT]):
             pass
         else:
             object.__delattr__(self, "value")
-            try:
-                return v
-            finally:
-                del v
+            return v
         raise AlreadyUsedError
 
     def send(self, gen: Generator[ResultT, ValueT, object]) -> ResultT:
@@ -218,10 +215,7 @@ class Error(Outcome[NoReturn]):
             pass
         else:
             object.__delattr__(self, "error")
-            try:
-                return v
-            finally:
-                del v
+            return v
         raise AlreadyUsedError
 
     def unwrap(self) -> NoReturn:

--- a/src/outcome/_impl.py
+++ b/src/outcome/_impl.py
@@ -122,13 +122,6 @@ class Outcome(abc.ABC, Generic[ValueT]):
     hashable.
 
     """
-    _unwrapped: bool = attr.ib(default=False, eq=False, init=False)
-
-    def _set_unwrapped(self) -> None:
-        if self._unwrapped:
-            raise AlreadyUsedError
-        object.__setattr__(self, '_unwrapped', True)
-
     @abc.abstractmethod
     def unwrap(self) -> ValueT:
         """Return or raise the contained value or exception.
@@ -174,19 +167,29 @@ class Value(Outcome[ValueT], Generic[ValueT]):
     """The contained value."""
 
     def __repr__(self) -> str:
-        return f'Value({self.value!r})'
+        try:
+            return f'Value({self.value!r})'
+        except AttributeError:
+            return f'Value(<DEAD>)'
 
     def unwrap(self) -> ValueT:
-        self._set_unwrapped()
-        return self.value
+        try:
+            v = self.value
+        except AttributeError:
+            pass
+        else:
+            object.__delattr__(self, "value")
+            try:
+                return v
+            finally:
+                del v
+        raise AlreadyUsedError
 
     def send(self, gen: Generator[ResultT, ValueT, object]) -> ResultT:
-        self._set_unwrapped()
-        return gen.send(self.value)
+        return gen.send(self.unwrap())
 
     async def asend(self, agen: AsyncGenerator[ResultT, ValueT]) -> ResultT:
-        self._set_unwrapped()
-        return await agen.asend(self.value)
+        return await agen.asend(self.unwrap())
 
 
 @final
@@ -202,13 +205,28 @@ class Error(Outcome[NoReturn]):
     """The contained exception object."""
 
     def __repr__(self) -> str:
-        return f'Error({self.error!r})'
+        try:
+            return f'Error({self.error!r})'
+        except AttributeError:
+            return 'Error(<DEAD>)'
+
+    def _unwrap_error(self) -> BaseException:
+        try:
+            v = self.error
+        except AttributeError:
+            pass
+        else:
+            object.__delattr__(self, "error")
+            try:
+                return v
+            finally:
+                del v
+        raise AlreadyUsedError
 
     def unwrap(self) -> NoReturn:
-        self._set_unwrapped()
         # Tracebacks show the 'raise' line below out of context, so let's give
         # this variable a name that makes sense out of context.
-        captured_error = self.error
+        captured_error = self._unwrap_error()
         try:
             raise captured_error
         finally:
@@ -227,12 +245,10 @@ class Error(Outcome[NoReturn]):
             del captured_error, self
 
     def send(self, gen: Generator[ResultT, NoReturn, object]) -> ResultT:
-        self._set_unwrapped()
-        return gen.throw(self.error)
+        return gen.throw(self._unwrap_error())
 
     async def asend(self, agen: AsyncGenerator[ResultT, NoReturn]) -> ResultT:
-        self._set_unwrapped()
-        return await agen.athrow(self.error)
+        return await agen.athrow(self._unwrap_error())
 
 
 # A convenience alias to a union of both results, allowing exhaustiveness checking.

--- a/src/outcome/_impl.py
+++ b/src/outcome/_impl.py
@@ -122,6 +122,7 @@ class Outcome(abc.ABC, Generic[ValueT]):
     hashable.
 
     """
+
     @abc.abstractmethod
     def unwrap(self) -> ValueT:
         """Return or raise the contained value or exception.

--- a/src/outcome/_impl.py
+++ b/src/outcome/_impl.py
@@ -258,7 +258,7 @@ class Error(Outcome[NoReturn]):
             #
             #    https://github.com/python-trio/trio/issues/1770
             #
-            # In particuar, by deleting this local variables from the 'unwrap'
+            # In particuar, by deleting this local variables from the 'peek'
             # methods frame, we avoid the 'captured_error' object's
             # __traceback__ from indirectly referencing 'captured_error'.
             del captured_error, self

--- a/src/outcome/_impl.py
+++ b/src/outcome/_impl.py
@@ -164,22 +164,22 @@ class Value(Outcome[ValueT], Generic[ValueT]):
 
     """
 
-    value: ValueT = attr.ib()
+    _value: ValueT = attr.ib()
     """The contained value."""
 
     def __repr__(self) -> str:
         try:
-            return f'Value({self.value!r})'
+            return f'Value({self._value!r})'
         except AttributeError:
             return f'Value(<AlreadyUsed>)'
 
     def unwrap(self) -> ValueT:
         try:
-            v = self.value
-        except AttributeError:
+            v = self._value
+        except AttributeError as e:
             pass
         else:
-            object.__delattr__(self, "value")
+            object.__delattr__(self, "_value")
             return v
         raise AlreadyUsedError
 
@@ -189,6 +189,14 @@ class Value(Outcome[ValueT], Generic[ValueT]):
     async def asend(self, agen: AsyncGenerator[ResultT, ValueT]) -> ResultT:
         return await agen.asend(self.unwrap())
 
+    @property
+    def value(self) -> ValueT:
+        try:
+            return self._value
+        except AttributeError as e:
+            pass
+        raise AlreadyUsedError
+
 
 @final
 @attr.s(frozen=True, repr=False, slots=True)
@@ -197,24 +205,24 @@ class Error(Outcome[NoReturn]):
 
     """
 
-    error: BaseException = attr.ib(
+    _error: BaseException = attr.ib(
         validator=attr.validators.instance_of(BaseException)
     )
     """The contained exception object."""
 
     def __repr__(self) -> str:
         try:
-            return f'Error({self.error!r})'
+            return f'Error({self._error!r})'
         except AttributeError:
             return 'Error(<AlreadyUsed>)'
 
     def _unwrap_error(self) -> BaseException:
         try:
-            v = self.error
+            v = self._error
         except AttributeError:
             pass
         else:
-            object.__delattr__(self, "error")
+            object.__delattr__(self, "_error")
             return v
         raise AlreadyUsedError
 
@@ -244,6 +252,14 @@ class Error(Outcome[NoReturn]):
 
     async def asend(self, agen: AsyncGenerator[ResultT, NoReturn]) -> ResultT:
         return await agen.athrow(self._unwrap_error())
+
+    @property
+    def error(self) -> BaseException:
+        try:
+            return self._error
+        except AttributeError:
+            pass
+        raise AlreadyUsedError
 
 
 # A convenience alias to a union of both results, allowing exhaustiveness checking.

--- a/src/outcome/_impl.py
+++ b/src/outcome/_impl.py
@@ -171,7 +171,7 @@ class Value(Outcome[ValueT], Generic[ValueT]):
         try:
             return f'Value({self.value!r})'
         except AttributeError:
-            return f'Value(<DEAD>)'
+            return f'Value(<AlreadyUsed>)'
 
     def unwrap(self) -> ValueT:
         try:
@@ -206,7 +206,7 @@ class Error(Outcome[NoReturn]):
         try:
             return f'Error({self.error!r})'
         except AttributeError:
-            return 'Error(<DEAD>)'
+            return 'Error(<AlreadyUsed>)'
 
     def _unwrap_error(self) -> BaseException:
         try:

--- a/src/outcome/_impl.py
+++ b/src/outcome/_impl.py
@@ -164,22 +164,22 @@ class Value(Outcome[ValueT], Generic[ValueT]):
 
     """
 
-    value: ValueT = attr.ib()
+    _value: ValueT = attr.ib()
     """The contained value."""
 
     def __repr__(self) -> str:
         try:
-            return f'Value({self.value!r})'
+            return f'Value({self._value!r})'
         except AttributeError:
             return f'Value(<AlreadyUsed>)'
 
     def unwrap(self) -> ValueT:
         try:
-            v = self.value
+            v = self._value
         except AttributeError:
             pass
         else:
-            object.__delattr__(self, "value")
+            object.__delattr__(self, "_value")
             return v
         raise AlreadyUsedError
 
@@ -189,6 +189,10 @@ class Value(Outcome[ValueT], Generic[ValueT]):
     async def asend(self, agen: AsyncGenerator[ResultT, ValueT]) -> ResultT:
         return await agen.asend(self.unwrap())
 
+    @property
+    def value(self) -> ValueT:
+        return self.unwrap()
+
 
 @final
 @attr.s(frozen=True, repr=False, slots=True)
@@ -197,24 +201,24 @@ class Error(Outcome[NoReturn]):
 
     """
 
-    error: BaseException = attr.ib(
+    _error: BaseException = attr.ib(
         validator=attr.validators.instance_of(BaseException)
     )
     """The contained exception object."""
 
     def __repr__(self) -> str:
         try:
-            return f'Error({self.error!r})'
+            return f'Error({self._error!r})'
         except AttributeError:
             return 'Error(<AlreadyUsed>)'
 
     def _unwrap_error(self) -> BaseException:
         try:
-            v = self.error
+            v = self._error
         except AttributeError:
             pass
         else:
-            object.__delattr__(self, "error")
+            object.__delattr__(self, "_error")
             return v
         raise AlreadyUsedError
 
@@ -244,6 +248,10 @@ class Error(Outcome[NoReturn]):
 
     async def asend(self, agen: AsyncGenerator[ResultT, NoReturn]) -> ResultT:
         return await agen.athrow(self._unwrap_error())
+
+    @property
+    def error(self) -> BaseException:
+        return self._unwrap_error()
 
 
 # A convenience alias to a union of both results, allowing exhaustiveness checking.

--- a/src/outcome/_impl.py
+++ b/src/outcome/_impl.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import abc
+import copy
 from typing import (
     TYPE_CHECKING,
     AsyncGenerator,
@@ -125,10 +126,10 @@ class Outcome(abc.ABC, Generic[ValueT]):
 
     @abc.abstractmethod
     def peek(self) -> ValueT:
-        """Return or raise the contained value or exception, without
-        invalidating the outcome.
+        """Return the contained value or raise a copy of the contained
+        exception, without invalidating the outcome.
 
-        These two lines of code are equivalent::
+        These two lines of code are almost equivalent::
 
            x = fn(*args)
            x = outcome.capture(fn, *args).peek()
@@ -245,7 +246,7 @@ class Error(Outcome[NoReturn]):
     def peek(self) -> NoReturn:
         # Tracebacks show the 'raise' line below out of context, so let's give
         # this variable a name that makes sense out of context.
-        captured_error = self.error
+        captured_error = copy.copy(self.error)
         try:
             raise captured_error
         finally:

--- a/src/outcome/_impl.py
+++ b/src/outcome/_impl.py
@@ -122,6 +122,7 @@ class Outcome(abc.ABC, Generic[ValueT]):
     hashable.
 
     """
+
     @abc.abstractmethod
     def peek(self) -> ValueT:
         """Return or raise the contained value or exception, without
@@ -133,7 +134,6 @@ class Outcome(abc.ABC, Generic[ValueT]):
            x = outcome.capture(fn, *args).peek()
 
         """
-
 
     @abc.abstractmethod
     def unwrap(self) -> ValueT:

--- a/src/outcome/_impl.py
+++ b/src/outcome/_impl.py
@@ -179,7 +179,6 @@ class Value(Outcome[ValueT], Generic[ValueT]):
     """
 
     _value: ValueT = attr.ib()
-    """The contained value."""
 
     def __repr__(self) -> str:
         try:
@@ -208,6 +207,7 @@ class Value(Outcome[ValueT], Generic[ValueT]):
 
     @property
     def value(self) -> ValueT:
+        """The contained value."""
         try:
             return self._value
         except AttributeError as e:
@@ -225,7 +225,6 @@ class Error(Outcome[NoReturn]):
     _error: BaseException = attr.ib(
         validator=attr.validators.instance_of(BaseException)
     )
-    """The contained exception object."""
 
     def __repr__(self) -> str:
         try:
@@ -293,6 +292,7 @@ class Error(Outcome[NoReturn]):
 
     @property
     def error(self) -> BaseException:
+        """The contained exception object."""
         try:
             return self._error
         except AttributeError:

--- a/src/outcome/_impl.py
+++ b/src/outcome/_impl.py
@@ -164,22 +164,22 @@ class Value(Outcome[ValueT], Generic[ValueT]):
 
     """
 
-    _value: ValueT = attr.ib()
+    value: ValueT = attr.ib()
     """The contained value."""
 
     def __repr__(self) -> str:
         try:
-            return f'Value({self._value!r})'
+            return f'Value({self.value!r})'
         except AttributeError:
             return f'Value(<AlreadyUsed>)'
 
     def unwrap(self) -> ValueT:
         try:
-            v = self._value
+            v = self.value
         except AttributeError:
             pass
         else:
-            object.__delattr__(self, "_value")
+            object.__delattr__(self, "value")
             return v
         raise AlreadyUsedError
 
@@ -189,10 +189,6 @@ class Value(Outcome[ValueT], Generic[ValueT]):
     async def asend(self, agen: AsyncGenerator[ResultT, ValueT]) -> ResultT:
         return await agen.asend(self.unwrap())
 
-    @property
-    def value(self) -> ValueT:
-        return self.unwrap()
-
 
 @final
 @attr.s(frozen=True, repr=False, slots=True)
@@ -201,24 +197,24 @@ class Error(Outcome[NoReturn]):
 
     """
 
-    _error: BaseException = attr.ib(
+    error: BaseException = attr.ib(
         validator=attr.validators.instance_of(BaseException)
     )
     """The contained exception object."""
 
     def __repr__(self) -> str:
         try:
-            return f'Error({self._error!r})'
+            return f'Error({self.error!r})'
         except AttributeError:
             return 'Error(<AlreadyUsed>)'
 
     def _unwrap_error(self) -> BaseException:
         try:
-            v = self._error
+            v = self.error
         except AttributeError:
             pass
         else:
-            object.__delattr__(self, "_error")
+            object.__delattr__(self, "error")
             return v
         raise AlreadyUsedError
 
@@ -248,10 +244,6 @@ class Error(Outcome[NoReturn]):
 
     async def asend(self, agen: AsyncGenerator[ResultT, NoReturn]) -> ResultT:
         return await agen.athrow(self._unwrap_error())
-
-    @property
-    def error(self) -> BaseException:
-        return self._unwrap_error()
 
 
 # A convenience alias to a union of both results, allowing exhaustiveness checking.

--- a/src/outcome/_impl.py
+++ b/src/outcome/_impl.py
@@ -171,7 +171,7 @@ class Value(Outcome[ValueT], Generic[ValueT]):
         try:
             return f'Value({self._value!r})'
         except AttributeError:
-            return f'Value(<AlreadyUsed>)'
+            return 'Value(<AlreadyUsed>)'
 
     def unwrap(self) -> ValueT:
         try:

--- a/src/outcome/_impl.py
+++ b/src/outcome/_impl.py
@@ -122,10 +122,23 @@ class Outcome(abc.ABC, Generic[ValueT]):
     hashable.
 
     """
+    @abc.abstractmethod
+    def peek(self) -> ValueT:
+        """Return or raise the contained value or exception, without
+        invalidating the outcome.
+
+        These two lines of code are equivalent::
+
+           x = fn(*args)
+           x = outcome.capture(fn, *args).peek()
+
+        """
+
 
     @abc.abstractmethod
     def unwrap(self) -> ValueT:
-        """Return or raise the contained value or exception.
+        """Return or raise the contained value or exception, and invalidate
+        the outcome.
 
         These two lines of code are equivalent::
 
@@ -172,6 +185,9 @@ class Value(Outcome[ValueT], Generic[ValueT]):
             return f'Value({self._value!r})'
         except AttributeError:
             return 'Value(<AlreadyUsed>)'
+
+    def peek(self) -> ValueT:
+        return self.value
 
     def unwrap(self) -> ValueT:
         try:
@@ -225,6 +241,27 @@ class Error(Outcome[NoReturn]):
             object.__delattr__(self, "_error")
             return v
         raise AlreadyUsedError
+
+    def peek(self) -> NoReturn:
+        # Tracebacks show the 'raise' line below out of context, so let's give
+        # this variable a name that makes sense out of context.
+        captured_error = self.error
+        try:
+            raise captured_error
+        finally:
+            # We want to avoid creating a reference cycle here. Python does
+            # collect cycles just fine, so it wouldn't be the end of the world
+            # if we did create a cycle, but the cyclic garbage collector adds
+            # latency to Python programs, and the more cycles you create, the
+            # more often it runs, so it's nicer to avoid creating them in the
+            # first place. For more details see:
+            #
+            #    https://github.com/python-trio/trio/issues/1770
+            #
+            # In particuar, by deleting this local variables from the 'unwrap'
+            # methods frame, we avoid the 'captured_error' object's
+            # __traceback__ from indirectly referencing 'captured_error'.
+            del captured_error, self
 
     def unwrap(self) -> NoReturn:
         # Tracebacks show the 'raise' line below out of context, so let's give

--- a/src/outcome/_impl.py
+++ b/src/outcome/_impl.py
@@ -190,14 +190,9 @@ class Value(Outcome[ValueT], Generic[ValueT]):
         return self.value
 
     def unwrap(self) -> ValueT:
-        try:
-            v = self._value
-        except AttributeError as e:
-            pass
-        else:
-            object.__delattr__(self, "_value")
-            return v
-        raise AlreadyUsedError
+        v = self.value
+        object.__delattr__(self, "_value")
+        return v
 
     def send(self, gen: Generator[ResultT, ValueT, object]) -> ResultT:
         return gen.send(self.unwrap())
@@ -233,14 +228,9 @@ class Error(Outcome[NoReturn]):
             return 'Error(<AlreadyUsed>)'
 
     def _unwrap_error(self) -> BaseException:
-        try:
-            v = self._error
-        except AttributeError:
-            pass
-        else:
-            object.__delattr__(self, "_error")
-            return v
-        raise AlreadyUsedError
+        v = self.error
+        object.__delattr__(self, "_error")
+        return v
 
     def peek(self) -> NoReturn:
         # Tracebacks show the 'raise' line below out of context, so let's give

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -22,8 +22,9 @@ async def test_acapture():
         raise ValueError(x)
 
     e = await outcome.acapture(raise_ValueError, 9)
-    assert type(e.error) is ValueError
-    assert e.error.args == (9,)
+    error = e.error
+    assert type(error) is ValueError
+    assert error.args == (9,)
 
 
 async def test_asend():

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -22,9 +22,8 @@ async def test_acapture():
         raise ValueError(x)
 
     e = await outcome.acapture(raise_ValueError, 9)
-    error = e.error
-    assert type(error) is ValueError
-    assert error.args == (9,)
+    assert type(e.error) is ValueError
+    assert e.error.args == (9,)
 
 
 async def test_asend():

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -25,10 +25,12 @@ async def test_acapture():
     e = await outcome.acapture(raise_ValueError, 9)
     assert type(e.error) is ValueError
     assert e.error.args == (9,)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc_info:
         e.peek()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc_info2:
         e.unwrap()
+
+    assert exc_info.value is not exc_info2.value
 
 
 async def test_asend():

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -16,6 +16,7 @@ async def test_acapture():
 
     v = await outcome.acapture(add, 3, y=4)
     assert v == Value(7)
+    assert v.peek() == 7
 
     async def raise_ValueError(x):
         await asyncio.sleep(0)
@@ -24,6 +25,10 @@ async def test_acapture():
     e = await outcome.acapture(raise_ValueError, 9)
     assert type(e.error) is ValueError
     assert e.error.args == (9,)
+    with pytest.raises(ValueError):
+        e.peek()
+    with pytest.raises(ValueError):
+        e.unwrap()
 
 
 async def test_asend():

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -10,8 +10,9 @@ from outcome import AlreadyUsedError, Error, Value
 def test_Outcome():
     v = Value(1)
     assert v.value == 1
-    assert v.unwrap() == 1
     assert repr(v) == "Value(1)"
+    assert v.unwrap() == 1
+    assert repr(v) == "Value(<DEAD>)"
 
     with pytest.raises(AlreadyUsedError):
         v.unwrap()
@@ -21,11 +22,12 @@ def test_Outcome():
     exc = RuntimeError("oops")
     e = Error(exc)
     assert e.error is exc
+    assert repr(e) == f"Error({exc!r})"
     with pytest.raises(RuntimeError):
         e.unwrap()
     with pytest.raises(AlreadyUsedError):
         e.unwrap()
-    assert repr(e) == f"Error({exc!r})"
+    assert repr(e) == "Error(<DEAD>)"
 
     e = Error(exc)
     with pytest.raises(TypeError):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -27,7 +27,7 @@ def test_Outcome():
         e.unwrap()
     with pytest.raises(AlreadyUsedError):
         e.unwrap()
-    assert repr(e) == "Error(<DEAD>)"
+    assert repr(e) == "Error(<AlreadyUsed>)"
 
     e = Error(exc)
     with pytest.raises(TypeError):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -12,7 +12,7 @@ def test_Outcome():
     assert v.value == 1
     assert repr(v) == "Value(1)"
     assert v.unwrap() == 1
-    assert repr(v) == "Value(<DEAD>)"
+    assert repr(v) == "Value(<AlreadyUsed>)"
 
     with pytest.raises(AlreadyUsedError):
         v.unwrap()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -10,6 +10,7 @@ from outcome import AlreadyUsedError, Error, Value
 def test_Outcome():
     v = Value(1)
     assert v.value == 1
+    v = Value(1)
     assert repr(v) == "Value(1)"
     assert v.unwrap() == 1
     assert repr(v) == "Value(<AlreadyUsed>)"
@@ -21,13 +22,16 @@ def test_Outcome():
 
     exc = RuntimeError("oops")
     e = Error(exc)
-    assert e.error is exc
+    error = e.error
+    assert error is exc
+    e = Error(exc)
     assert repr(e) == f"Error({exc!r})"
+    e = Error(exc)
     with pytest.raises(RuntimeError):
         e.unwrap()
     with pytest.raises(AlreadyUsedError):
         e.unwrap()
-    assert repr(e) == "Error(<DEAD>)"
+    assert repr(e) == "Error(<AlreadyUsed>)"
 
     e = Error(exc)
     with pytest.raises(TypeError):
@@ -101,8 +105,9 @@ def test_capture():
 
     e = outcome.capture(raise_ValueError, "two")
     assert type(e) == Error
-    assert type(e.error) is ValueError
-    assert e.error.args == ("two",)
+    error = e.error
+    assert type(error) is ValueError
+    assert error.args == ("two",)
 
 
 def test_inheritance():

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -10,7 +10,6 @@ from outcome import AlreadyUsedError, Error, Value
 def test_Outcome():
     v = Value(1)
     assert v.value == 1
-    v = Value(1)
     assert repr(v) == "Value(1)"
     assert v.unwrap() == 1
     assert repr(v) == "Value(<AlreadyUsed>)"
@@ -22,16 +21,13 @@ def test_Outcome():
 
     exc = RuntimeError("oops")
     e = Error(exc)
-    error = e.error
-    assert error is exc
-    e = Error(exc)
+    assert e.error is exc
     assert repr(e) == f"Error({exc!r})"
-    e = Error(exc)
     with pytest.raises(RuntimeError):
         e.unwrap()
     with pytest.raises(AlreadyUsedError):
         e.unwrap()
-    assert repr(e) == "Error(<AlreadyUsed>)"
+    assert repr(e) == "Error(<DEAD>)"
 
     e = Error(exc)
     with pytest.raises(TypeError):
@@ -105,9 +101,8 @@ def test_capture():
 
     e = outcome.capture(raise_ValueError, "two")
     assert type(e) == Error
-    error = e.error
-    assert type(error) is ValueError
-    assert error.args == ("two",)
+    assert type(e.error) is ValueError
+    assert e.error.args == ("two",)
 
 
 def test_inheritance():

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -24,10 +24,13 @@ def test_Outcome():
     e = Error(exc)
     assert e.error is exc
     assert repr(e) == f"Error({exc!r})"
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError) as exc_info:
         e.peek()
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError) as exc_info2:
         e.unwrap()
+
+    assert exc_info.value is not exc_info2.value
+
     with pytest.raises(AlreadyUsedError):
         e.unwrap()
     assert repr(e) == "Error(<AlreadyUsed>)"

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -11,6 +11,7 @@ def test_Outcome():
     v = Value(1)
     assert v.value == 1
     assert repr(v) == "Value(1)"
+    assert v.peek() == 1
     assert v.unwrap() == 1
     assert repr(v) == "Value(<AlreadyUsed>)"
 
@@ -23,6 +24,8 @@ def test_Outcome():
     e = Error(exc)
     assert e.error is exc
     assert repr(e) == f"Error({exc!r})"
+    with pytest.raises(RuntimeError):
+        e.peek()
     with pytest.raises(RuntimeError):
         e.unwrap()
     with pytest.raises(AlreadyUsedError):
@@ -94,6 +97,7 @@ def test_capture():
 
     v = outcome.capture(add, 2, y=3)
     assert type(v) == Value
+    assert v.peek() == 5
     assert v.unwrap() == 5
 
     def raise_ValueError(x):
@@ -103,6 +107,10 @@ def test_capture():
     assert type(e) == Error
     assert type(e.error) is ValueError
     assert e.error.args == ("two",)
+    with pytest.raises(ValueError):
+        e.peek()
+    with pytest.raises(ValueError):
+        e.unwrap()
 
 
 def test_inheritance():


### PR DESCRIPTION
Fixes #47 

currently unwraping exceptions leaves a refcycle that keeps the entire traceback and any locals alive. This PR resolves that by clearing the error field when the Error is unwrapped.

For the previous behaviour of Value (eg in trio) if you receive a large bytes object in a Value that bytes object stays alive long after it's needed. This PR resolves that by clearing the value field when the Value is unwrapped.

this is a breaking change and should probably be released with a major version bump, eg outcome==2.0.0