### PR TITLE
add .unwrap_and_destroy() method to remove reference to value/error when unwrapping outcome

### DIFF
--- a/newsfragments/47.feature.rst
+++ b/newsfragments/47.feature.rst
@@ -1,0 +1,5 @@
+Add ``unwrap_and_destroy`` method to remove references to
+the wrapped exception or value to prevent issues where
+values not being garbage collected when they are no longer
+needed, or worse problems with exceptions leaving a
+reference cycle.

--- a/src/outcome/_impl.py
+++ b/src/outcome/_impl.py
@@ -200,7 +200,7 @@ class Value(Outcome[ValueT], Generic[ValueT]):
         self._set_unwrapped()
         return self.value
 
-    def unwrap_and_destroy(self):
+    def unwrap_and_destroy(self) -> ValueT:
         self._set_unwrapped()
         v = self.value
         object.__delattr__(self, "value")

--- a/src/outcome/_impl.py
+++ b/src/outcome/_impl.py
@@ -231,7 +231,7 @@ class Error(Outcome[NoReturn]):
         try:
             return f'Error({self.error!r})'
         except AttributeError:
-            return f'Error(<AlreadyDestroyed>)'
+            return 'Error(<AlreadyDestroyed>)'
 
     def unwrap(self) -> NoReturn:
         self._set_unwrapped()

--- a/src/outcome/_impl.py
+++ b/src/outcome/_impl.py
@@ -138,6 +138,23 @@ class Outcome(abc.ABC, Generic[ValueT]):
            x = fn(*args)
            x = outcome.capture(fn, *args).unwrap()
 
+        Note: this leaves a reference to the contained value or exception
+        alive which may result in values not being garbage collected or
+        exceptions leaving a reference cycle. If this is an issue it's
+        recommended to call the ``unwrap_and_destroy()`` method
+
+        """
+
+    @abc.abstractmethod
+    def unwrap_and_destroy(self) -> ValueT:
+        """Return or raise the contained value or exception, remove the
+        reference to the contained value or exception.
+
+        These two lines of code are equivalent::
+
+           x = fn(*args)
+           x = outcome.capture(fn, *args).unwrap_and_destroy()
+
         """
 
     @abc.abstractmethod
@@ -174,11 +191,20 @@ class Value(Outcome[ValueT], Generic[ValueT]):
     """The contained value."""
 
     def __repr__(self) -> str:
-        return f'Value({self.value!r})'
+        try:
+            return f'Value({self.value!r})'
+        except AttributeError:
+            return f'Value(<AlreadyDestroyed>)'
 
     def unwrap(self) -> ValueT:
         self._set_unwrapped()
         return self.value
+
+    def unwrap_and_destroy(self):
+        self._set_unwrapped()
+        v = self.value
+        object.__delattr__(self, "value")
+        return v
 
     def send(self, gen: Generator[ResultT, ValueT, object]) -> ResultT:
         self._set_unwrapped()
@@ -202,13 +228,39 @@ class Error(Outcome[NoReturn]):
     """The contained exception object."""
 
     def __repr__(self) -> str:
-        return f'Error({self.error!r})'
+        try:
+            return f'Error({self.error!r})'
+        except AttributeError:
+            return f'Error(<AlreadyDestroyed>)'
 
     def unwrap(self) -> NoReturn:
         self._set_unwrapped()
         # Tracebacks show the 'raise' line below out of context, so let's give
         # this variable a name that makes sense out of context.
         captured_error = self.error
+        try:
+            raise captured_error
+        finally:
+            # We want to avoid creating a reference cycle here. Python does
+            # collect cycles just fine, so it wouldn't be the end of the world
+            # if we did create a cycle, but the cyclic garbage collector adds
+            # latency to Python programs, and the more cycles you create, the
+            # more often it runs, so it's nicer to avoid creating them in the
+            # first place. For more details see:
+            #
+            #    https://github.com/python-trio/trio/issues/1770
+            #
+            # In particuar, by deleting this local variables from the 'unwrap'
+            # methods frame, we avoid the 'captured_error' object's
+            # __traceback__ from indirectly referencing 'captured_error'.
+            del captured_error, self
+
+    def unwrap_and_destroy(self) -> NoReturn:
+        self._set_unwrapped()
+        # Tracebacks show the 'raise' line below out of context, so let's give
+        # this variable a name that makes sense out of context.
+        captured_error = self.error
+        object.__delattr__(self, "error")
         try:
             raise captured_error
         finally:

--- a/src/outcome/_impl.py
+++ b/src/outcome/_impl.py
@@ -194,7 +194,7 @@ class Value(Outcome[ValueT], Generic[ValueT]):
         try:
             return f'Value({self.value!r})'
         except AttributeError:
-            return f'Value(<AlreadyDestroyed>)'
+            return 'Value(<AlreadyDestroyed>)'
 
     def unwrap(self) -> ValueT:
         self._set_unwrapped()

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -117,7 +117,3 @@ async def test_unwrap_and_destroy_does_not_leave_a_refcycle():
         assert coro.send(None) == "network operation"
         with pytest.raises(StopIteration):
             coro.send(outcome.Error(MyException()))
-
-
-if __name__ == "__main__":
-    sys.exit(main())

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,17 +1,16 @@
 import asyncio
+import contextlib
+import gc
+import platform
+import sys
 import traceback
+import types
+import weakref
 
 import pytest
 
 import outcome
 from outcome import AlreadyUsedError, Error, Value
-import weakref
-import sys
-import contextlib
-import types
-import outcome
-import platform
-import gc
 
 pytestmark = pytest.mark.asyncio
 

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -5,6 +5,13 @@ import pytest
 
 import outcome
 from outcome import AlreadyUsedError, Error, Value
+import weakref
+import sys
+import contextlib
+import types
+import outcome
+import platform
+import gc
 
 pytestmark = pytest.mark.asyncio
 
@@ -58,3 +65,60 @@ async def test_traceback_frame_removal():
     frames = traceback.extract_tb(exc_info.value.__traceback__)
     functions = [function for _, _, function, _ in frames]
     assert functions[-2:] == ['unwrap', 'raise_ValueError']
+
+
+@types.coroutine
+def async_yield(v):
+    return (yield v)
+
+
+async def test_unwrap_leaves_a_refcycle():
+    class MyException(Exception):
+        pass
+
+    async def network_operation():
+        return (await async_yield("network operation")).unwrap()
+
+    async def coro_fn():
+        try:
+            await network_operation()
+        except MyException as e:
+            wr_e = weakref.ref(e)
+            del e
+
+        if platform.python_implementation() == "PyPy":
+            gc.collect()
+        assert isinstance(wr_e(), MyException)
+
+    with contextlib.closing(coro_fn()) as coro:
+        assert coro.send(None) == "network operation"
+        with pytest.raises(StopIteration):
+            coro.send(outcome.Error(MyException()))
+
+
+async def test_unwrap_and_destroy_does_not_leave_a_refcycle():
+    class MyException(Exception):
+        pass
+
+    async def network_operation():
+        return (await async_yield("network operation")).unwrap_and_destroy()
+
+    async def coro_fn():
+        try:
+            await network_operation()
+        except MyException as e:
+            wr_e = weakref.ref(e)
+            del e
+
+        if platform.python_implementation() == "PyPy":
+            gc.collect()
+        assert wr_e() is None
+
+    with contextlib.closing(coro_fn()) as coro:
+        assert coro.send(None) == "network operation"
+        with pytest.raises(StopIteration):
+            coro.send(outcome.Error(MyException()))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -16,7 +16,11 @@ def test_Outcome():
     with pytest.raises(AlreadyUsedError):
         v.unwrap()
 
-    v = Value(1)
+    v = Value(2)
+    assert v.unwrap_and_destroy() == 2
+    assert repr(v) == "Value(<AlreadyDestroyed>)"
+    with pytest.raises(AlreadyUsedError):
+        v.unwrap_and_destroy()
 
     exc = RuntimeError("oops")
     e = Error(exc)
@@ -33,12 +37,20 @@ def test_Outcome():
     with pytest.raises(TypeError):
         Error(RuntimeError)
 
+    e2 = Error(exc)
+    with pytest.raises(RuntimeError):
+        e2.unwrap_and_destroy()
+    with pytest.raises(AlreadyUsedError):
+        e2.unwrap_and_destroy()
+    assert repr(e2) == "Error(<AlreadyDestroyed>)"
+
     def expect_1():
         assert (yield) == 1
         yield "ok"
 
     it = iter(expect_1())
     next(it)
+    v = Value(1)
     assert v.send(it) == "ok"
     with pytest.raises(AlreadyUsedError):
         v.send(it)


### PR DESCRIPTION
Fixes #47 

currently unwraping exceptions leaves a refcycle that keeps the entire traceback and any locals alive. This PR resolves that by clearing the error field when the Error is unwrap_and_destroy-ed.

For the previous behaviour of Value (eg in trio) if you receive a large bytes object in a Value that bytes object stays alive long after it's needed. This PR resolves that by clearing the value field when the Value is unwrap_and_destroy-ed.

this is an alternative approach to https://github.com/python-trio/outcome/pull/45 that is fully backwards compatible and will only need a minor version bump, eg `outcome==1.4.0`